### PR TITLE
Disable aarch64 builds

### DIFF
--- a/.github/workflows/cron_build.yml
+++ b/.github/workflows/cron_build.yml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
+      max-parallel: 4
+      fail-fast: false
     steps:
       - name: Check if driver-toolkit image exists for kernel ${{ matrix.versions.kernel }}
         id: get-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN --mount=type=secret,id=RHSM_ORG \
     rm /etc/rhsm-host \
     && /usr/local/bin/rhsm-register \
     && subscription-manager repos \
-        --enable rhel-8-for-x86_64-baseos-rpms \
-        --enable rhel-8-for-x86_64-appstream-rpms \
-        --enable=rhel-8-for-x86_64-baseos-eus-rpms \
+        --enable rhel-8-for-$(arch)-baseos-rpms \
+        --enable rhel-8-for-$(arch)-appstream-rpms \
+        --enable=rhel-8-for-$(arch)-baseos-eus-rpms \
     && echo "${RHEL_VERSION}" > /etc/dnf/vars/releasever \
     && dnf config-manager --best --nodocs --setopt=install_weak_deps=False --save \
     && dnf -y install \

--- a/build-matrix.sh
+++ b/build-matrix.sh
@@ -10,7 +10,7 @@ echo "Generating matrix in ${MATRIX_FILE}"
 KVERS=()
 for y in $(seq 8 10); do
     for z in $(seq 0 99); do
-	for a in "x86_64" "aarch64"; do
+	for a in "x86_64"; do
             # Get the release image for the z-stream
 	    echo -n "Get the release image for OCP 4.${y}.${z}-${a}."
             IMG=$(oc adm release info --image-for=machine-os-content quay.io/openshift-release-dev/ocp-release:4.${y}.${z}-${a} 2>/dev/null)
@@ -59,9 +59,6 @@ for KVER_NOARCH in ${KVERS_NOARCH[@]}; do
 
     # Initialize the archs with x86_64" which is mandatory
     ARCHS="linux/amd64"
-
-    # Add aarch64 to the archs if a kernel for aarch64 is in the list
-    [[ " ${KVERS[*]} " =~ " ${KVER_NOARCH}.aarch64 " ]] && ARCHS="${ARCHS},linux/arm64"
 
     # Add a comma for all entries but the first one
     [ ${COUNT} -gt 0 ] && echo -n "," >> ${MATRIX_FILE}


### PR DESCRIPTION
Some kernel versions are not available in the main repositories. Until
we find a clean way to get them, some of the images will be broken.
This change disables the `aarch64` architecture.

It also reduce the job concurrency for builds.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>