### PR TITLE
Add Dependabot config for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+  # Maintain dependencies for Github Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This change enables Dependabot for Github Actions, in order to keep the
dependencies up-to-date.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>