### PR TITLE
Add a build condition on UBI digest

### DIFF
--- a/.github/workflows/cron_build.yml
+++ b/.github/workflows/cron_build.yml
@@ -39,31 +39,55 @@ jobs:
       fail-fast: false
     steps:
       - name: Check if driver-toolkit image exists for kernel ${{ matrix.versions.kernel }}
-        id: get-image
+        id: check-existing-image
         continue-on-error: true
         run: curl --fail https://${{ env.REGISTRY }}/v2/${{ github.repository }}/manifests/${{ matrix.versions.kernel }}
 
+      - name: Check if base image digest has changed
+        id: check-base-image-digest
+        if: steps.check-existing-image.outcome == 'success'
+        continue-on-error: true
+        run: |
+          UBI_DIGEST=$( \
+            oc image info \
+              --filter-by-os ${{ matrix.versions.arch }} -o json \
+              ${{ env.REGISTRY }}/${{ github.repository }}:${{ matrix.versions.kernel }} \
+            | jq .config.config.Labels[\"org.opencontainers.image.base.digest\"] \
+            | sed 's/"//g'
+          )
+          [[ "${UBI_DIGEST}" == "${{ matrix.versions.ubi-digest }}" ]]
+
       - name: Checkout current repository for the Dockerfiles
-        if: steps.get-image.outcome == 'failure'
+        if: |
+          steps.check-base-image-digest.outcome == 'failure' ||
+          steps.check-existing-image.outcome == 'failure'
         uses: actions/checkout@v2
 
       - name: Lint Dockerfile
-        if: steps.get-image.outcome == 'failure'
+        if: |
+          steps.check-base-image-digest.outcome == 'failure' ||
+          steps.check-existing-image.outcome == 'failure'
         uses: hadolint/hadolint-action@v1.7.0
         with:
           dockerfile: ./Dockerfile
           failure-threshold: error
 
       - name: Set up QEMU
-        if: steps.get-image.outcome == 'failure'
+        if: |
+          steps.check-base-image-digest.outcome == 'failure' ||
+          steps.check-existing-image.outcome == 'failure'
         uses: docker/setup-qemu-action@v1
 
       - name: Set up Docker Buildx
-        if: steps.get-image.outcome == 'failure'
+        if: |
+          steps.check-base-image-digest.outcome == 'failure' ||
+          steps.check-existing-image.outcome == 'failure'
         uses: docker/setup-buildx-action@v1
 
       - name: Login to the container registry
-        if: steps.get-image.outcome == 'failure'
+        if: |
+          steps.check-base-image-digest.outcome == 'failure' ||
+          steps.check-existing-image.outcome == 'failure'
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
@@ -71,16 +95,19 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build and push driver-toolkit:${{ matrix.versions.kernel }}
-        if: steps.get-image.outcome == 'failure'
+        if: |
+          steps.check-base-image-digest.outcome == 'failure' ||
+          steps.check-existing-image.outcome == 'failure'
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
           tags: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.versions.kernel }}"
-          platforms: "${{ matrix.versions.archs }}"
+          platforms: "${{ matrix.versions.arch }}"
           build-args: |
-            "RHEL_VERSION=${{ matrix.versions.rhel }}"
+            "BASE_DIGEST=${{ matrix.versions.ubi_digest }}"
             "KERNEL_VERSION=${{ matrix.versions.kernel }}"
+            "RHEL_VERSION=${{ matrix.versions.rhel }}"
           secrets: |
             "RHSM_ORG=${{ secrets.RHSM_ORG }}"
             "RHSM_ACTIVATIONKEY=${{ secrets.RHSM_ACTIVATIONKEY }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 ARG RHEL_VERSION=''
+ARG BASE_DIGEST=''
 
-FROM registry.access.redhat.com/ubi8/ubi:${RHEL_VERSION}
-
-USER root
+FROM registry.access.redhat.com/ubi8/ubi@${BASE_DIGEST}
 
 ARG RHEL_VERSION=''
+ARG BASE_DIGEST=''
 ARG KERNEL_VERSION=''
 ARG RT_KERNEL_VERSION=''
+
+USER root
 
 COPY ./rhsm-register /usr/local/bin/rhsm-register
 
@@ -39,6 +41,9 @@ RUN --mount=type=secret,id=RHSM_ORG \
 
 LABEL io.k8s.description="Driver Toolkit provides the packages required to build driver containers for a specific version of RHEL 8 kernel" \
       io.k8s.display-name="Driver Toolkit" \
+      org.opencontainers.image.base.name="registry.access.redhat.com/ubi8/ubi" \
+      org.opencontainers.image.base.digest="${BASE_DIGEST}" \
+      org.opencontainers.source="https://github.com/smgglrs/driver-toolkit" \
       maintainer="Smgglrs" \
       name="driver-toolkit" \
       vendor="Smgglrs" \

--- a/build-matrix.sh
+++ b/build-matrix.sh
@@ -57,15 +57,18 @@ for KVER_NOARCH in ${KVERS_NOARCH[@]}; do
     # Extract RHEL version from the kernel version
     RHEL_VERSION=$(echo ${KVER_NOARCH} | rev | cut -d "." -f 1 | rev | sed -e "s/^el//" -e "s/_/./")
 
+    # Retrieve UBI image digest for RHEL version
+    UBI_DIGEST=$(oc image info -o json --filter-by-os "linux/amd64" registry.access.redhat.com/ubi8/ubi:${RHEL_VERSION} | jq .digest)
+
     # Initialize the archs with x86_64" which is mandatory
-    ARCHS="linux/amd64"
+    ARCH="linux/amd64"
 
     # Add a comma for all entries but the first one
     [ ${COUNT} -gt 0 ] && echo -n "," >> ${MATRIX_FILE}
     ((COUNT++))
 
     # Generate the matrix entry for the kernel
-    echo -n " { \"rhel\": \"${RHEL_VERSION}\", \"kernel\": \"${KVER_NOARCH}\", \"archs\": \"${ARCHS}\" }" >> ${MATRIX_FILE}
+    echo -n " { \"rhel\": \"${RHEL_VERSION}\", \"ubi-digest\": ${UBI_DIGEST}, \"kernel\": \"${KVER_NOARCH}\", \"arch\": \"${ARCH}\" }" >> ${MATRIX_FILE}
 done
 
 # Finalize the matrix file


### PR DESCRIPTION
The `driver-toolkit` image is based on `ubi8/ubi` and we want to ensure
that is rebuilt when the parent image is updated. The minor release tag
is a floating tag and will point to a new image after an async update.

We store the base image digest in the
`org.opencontainers.image.base.digest` label of the final image, in
order to compare it with the `ubi8/ubi` digest for the floating tag.

If the digests don't match, it means that an updated base image is
available and we trigger and build/push of the `driver-toolkit` image.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>